### PR TITLE
task EXP-9851 – get rid of UIScreen.mainScreen in RDMPEG. We cannot u…

### DIFF
--- a/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.m
+++ b/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.m
@@ -112,7 +112,7 @@ static NSString * const RDMPEGPlayerInputSubtitleStreamsKey = @"RDMPEGPlayerInpu
         self.externalInputsQueue.maxConcurrentOperationCount = 1;
         
         self.framebuffer = [[RDMPEGFramebuffer alloc] init];
-        self.playerView = [[RDMPEGPlayerView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        self.playerView = [[RDMPEGPlayerView alloc] init];
         self.audioRenderer = [[RDMPEGAudioRenderer alloc] init];
         self.selectableInputs = [NSMutableArray array];
         


### PR DESCRIPTION
…se it anymore to properly support the use of second display that can be attached to M1 iPad