### PR TITLE
DOC-9721 Add log callback

### DIFF
--- a/RDMPEG/RDMPEGConverter/RDMobileFFmpegOperation.h
+++ b/RDMPEG/RDMPEGConverter/RDMobileFFmpegOperation.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^RDMobileFFmpegOperationStatisticsBlock)(RDMobileFFmpegStatistics *statistics);
 typedef void(^RDMobileFFmpegOperationResultBlock)(int result);
+typedef void(^RDMobileFFmpegOperationLogBlock)(NSString *log, int level);
 
 
 @interface RDMobileFFmpegOperation : RDMPEGOperation
@@ -26,6 +27,11 @@ typedef void(^RDMobileFFmpegOperationResultBlock)(int result);
 - (instancetype)initWithArguments:(NSArray<NSString *> *)arguments
                   statisticsBlock:(RDMobileFFmpegOperationStatisticsBlock)statisticsBlock
                       resultBlock:(RDMobileFFmpegOperationResultBlock)resultBlock;
+
+- (instancetype)initWithArguments:(NSArray<NSString *> *)arguments
+                  statisticsBlock:(RDMobileFFmpegOperationStatisticsBlock)statisticsBlock
+                      resultBlock:(RDMobileFFmpegOperationResultBlock)resultBlock
+                         logBlock:(__nullable RDMobileFFmpegOperationLogBlock)logBlock;
 
 + (BOOL)isReturnCodeCancel:(int)code;
 

--- a/RDMPEG/RDMPEGConverter/RDMobileFFmpegOperation.m
+++ b/RDMPEG/RDMPEGConverter/RDMobileFFmpegOperation.m
@@ -18,6 +18,7 @@
 @property (nonatomic,strong)NSArray<NSString *> *arguments;
 @property (nonatomic,copy)RDMobileFFmpegOperationResultBlock resultBlock;
 @property (nonatomic,copy)RDMobileFFmpegOperationStatisticsBlock statisticsBlock;
+@property (nonatomic, copy, nullable) RDMobileFFmpegOperationLogBlock logBlock;
 @property (atomic, strong) FFmpegSession *session;
 
 @end
@@ -28,6 +29,13 @@
 - (instancetype)initWithArguments:(NSArray<NSString *> *)arguments
                   statisticsBlock:(RDMobileFFmpegOperationStatisticsBlock)statisticsBlock
                       resultBlock:(RDMobileFFmpegOperationResultBlock)resultBlock{
+    return [self initWithArguments:arguments statisticsBlock:statisticsBlock resultBlock:resultBlock logBlock:nil];
+}
+
+- (instancetype)initWithArguments:(NSArray<NSString *> *)arguments
+                  statisticsBlock:(RDMobileFFmpegOperationStatisticsBlock)statisticsBlock
+                      resultBlock:(RDMobileFFmpegOperationResultBlock)resultBlock
+                         logBlock:(__nullable RDMobileFFmpegOperationLogBlock)logBlock {
     NSParameterAssert(arguments);
     if(arguments == nil){
         return nil;
@@ -37,6 +45,7 @@
         self.arguments = arguments;
         self.resultBlock = resultBlock;
         self.statisticsBlock = statisticsBlock;
+        self.logBlock = logBlock;
     }
     return self;
 }
@@ -57,6 +66,9 @@
         [weakSelf completeOperation];
      }
      withLogCallback:^(Log *log) {
+        if (weakSelf.logBlock) {
+            weakSelf.logBlock([log getMessage], [log getLevel]);
+        }
         log4CDebug(@"level: %@, message: %@", @([log getLevel]), [log getMessage]);
      }
      withStatisticsCallback:^(Statistics *statistics) {


### PR DESCRIPTION
Необходимо парсить аутпут ffmpeg'a, чтобы вычленить резултат silencedetect.
Есть еще вариант, который мне нравится меньше: указать энв переменную с путем куда складывать репорты, при этом имя лога указать нельзя, а значит придется вести поиск необходимого лога в директории. Вариант с logBlock выглядит лучше.
