### PR TITLE
[DOC-11434] - Loading default metal lib from rdmpeg bundle instead of…

### DIFF
--- a/RDMPEG/RDMPEGRenderView/RDMPEGRenderView.m
+++ b/RDMPEG/RDMPEGRenderView/RDMPEGRenderView.m
@@ -177,8 +177,13 @@ NS_ASSUME_NONNULL_BEGIN
     self.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
     self.framebufferOnly = YES;
     
-    id<MTLLibrary> const defaultLibrary = [self.device newDefaultLibrary];
-    
+//    id<MTLLibrary> const defaultLibrary = [self.device newDefaultLibrary];
+
+    NSError *libraryError;
+    id<MTLLibrary> const defaultLibrary = [self.device newDefaultLibraryWithBundle:[NSBundle bundleForClass:[self class]]
+                                                                             error:&libraryError];
+//    log4Assert(nil == defaultLibrary, @"Unable to create MTLLibrary: %@", libraryError);
+
     MTLRenderPipelineDescriptor * const pipelineStateDescriptor = [MTLRenderPipelineDescriptor new];
     pipelineStateDescriptor.vertexFunction = [defaultLibrary newFunctionWithName:@"vertexShader"];
     pipelineStateDescriptor.fragmentFunction = [self.textureSampler newSamplingFunctionFromLibrary:defaultLibrary];


### PR DESCRIPTION
[__Ticket link__](https://readdle-j.atlassian.net/browse/DOC-11434)

[DOC-11434](https://readdle-j.atlassian.net/browse/DOC-11434)

__PR description__

Метод `newDefaultLibrary` ищет библиотеку в main bundle. При этов в RDMPEG библиотека с шейдерами лежит в бандле фреймворка.

Добавил загрузку из бандла фреймворка и проверки наличия в библиотеке нужных функций так как метод `newFunctionWithName:` может вернуть nil.

Почему это работало в 8.10.8 выяснить не удалось.

__Screenshot / Videos__

If it would be useful, please, include screenshots, animated GIFs or screencasts of changes in action

__PR submission checklist__

- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed


[DOC-11434]: https://readdle-j.atlassian.net/browse/DOC-11434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ