### PR TITLE
DOC-14148: Limit maximum size of the audio buffer

### DIFF
--- a/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
+++ b/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
@@ -872,7 +872,12 @@ public class RDMPEGPlayer: NSObject {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func audioCallbackFillData(_ outData: UnsafeMutablePointer<Float>, numFrames: UInt32, numChannels: UInt32) {
-        autoreleasepool {
+        autoreleasepool { [weak self] in
+            guard let self = self else {
+                memset(outData, 0, Int(numFrames) * Int(numChannels) * MemoryLayout<Float>.size)
+                return
+            }
+            
             var outData = outData
 
             if videoStreamExist && correctionInfo == nil {
@@ -887,7 +892,7 @@ public class RDMPEGPlayer: NSObject {
             var numFramesLeft = numFrames
 
             while numFramesLeft > 0 {
-                if rawAudioFrame == nil {
+                if self.rawAudioFrame == nil {
                     var nextAudioFrame: RDMPEGAudioFrame?
                     var isAudioOutrun = false
                     var isAudioLags = false
@@ -896,7 +901,7 @@ public class RDMPEGPlayer: NSObject {
                     let loggingScope = L4Logger.logger(forName: "rd.mediaplayer.RDMPEGPlayer").loggingScope()
 #endif
 
-                    framebuffer.atomicAudioFramesAccess {
+                    self.framebuffer.atomicAudioFramesAccess {
                         if let nextFrame = self.framebuffer.nextAudioFrame {
                             let delta = self.correctionInfo?.correctionInterval(
                                 withCurrentTime: nextFrame.position
@@ -916,8 +921,8 @@ public class RDMPEGPlayer: NSObject {
 
                             nextAudioFrame = self.framebuffer.popAudioFrame()
 
-                            if videoStreamExist == false {
-                                currentInternalTime = nextAudioFrame?.position ?? 0
+                            if self.videoStreamExist == false {
+                                self.currentInternalTime = nextAudioFrame?.position ?? 0
                             }
 
                             if delta < -0.1, self.framebuffer.nextAudioFrame != nil {
@@ -947,12 +952,12 @@ public class RDMPEGPlayer: NSObject {
                             .debug("Audio frame will be rendered: \(audioFrame.position) \(audioFrame.duration)")
 #endif
 
-                        rawAudioFrame = RDMPEGRawAudioFrame(rawAudioData: audioFrame.samples)
+                        self.rawAudioFrame = RDMPEGRawAudioFrame(rawAudioData: audioFrame.samples)
 
-                        if videoStreamExist == false {
-                            correctionInfo = RDMPEGCorrectionInfo(
+                        if self.videoStreamExist == false {
+                            self.correctionInfo = RDMPEGCorrectionInfo(
                                 playbackStartDate: Date(),
-                                playbackStartTime: currentInternalTime
+                                playbackStartTime: self.currentInternalTime
                             )
 
                             DispatchQueue.main.async {
@@ -960,8 +965,8 @@ public class RDMPEGPlayer: NSObject {
                             }
                         }
                     }
-                    else if videoStreamExist == false {
-                        correctionInfo = nil
+                    else if self.videoStreamExist == false {
+                        self.correctionInfo = nil
 
                         DispatchQueue.main.async {
                             self.setBufferingStateIfNeededAndNotify(true)
@@ -969,7 +974,7 @@ public class RDMPEGPlayer: NSObject {
                     }
                 }
 
-                if let rawAudioFrame = rawAudioFrame {
+                if let rawAudioFrame = self.rawAudioFrame {
 #if RD_DEBUG_MPEG_PLAYER
                     L4Logger.logger(forName: "rd.mediaplayer.RDMPEGPlayer").debug("Rendering raw audio frame")
 #endif

--- a/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
+++ b/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
@@ -13,6 +13,7 @@ import ReaddleLib
 private let RDMPEGPlayerMinVideoBufferSize: TimeInterval = 0.2
 private let RDMPEGPlayerMaxVideoBufferSize: TimeInterval = 1.0
 private let RDMPEGPlayerMinAudioBufferSize: TimeInterval = 0.2
+private let RDMPEGPlayerMaxAudioBufferSize: TimeInterval = 1.0
 
 private let RDMPEGPlayerInputDecoderKey = "RDMPEGPlayerInputDecoderKey"
 private let RDMPEGPlayerInputNameKey = "RDMPEGPlayerInputNameKey"
@@ -1201,6 +1202,10 @@ public class RDMPEGPlayer: NSObject {
                     return true
                 }
 
+                if framebuffer.bufferedAudioDuration >= RDMPEGPlayerMaxAudioBufferSize {
+                    return true
+                }
+
                 if framebuffer.bufferedAudioDuration > RDMPEGPlayerMinAudioBufferSize {
                     return true
                 }
@@ -1216,6 +1221,10 @@ public class RDMPEGPlayer: NSObject {
                     return true
                 }
 
+                if framebuffer.bufferedAudioDuration >= RDMPEGPlayerMaxAudioBufferSize {
+                    return true
+                }
+
                 if framebuffer.bufferedAudioDuration > RDMPEGPlayerMinAudioBufferSize {
                     return true
                 }
@@ -1228,6 +1237,10 @@ public class RDMPEGPlayer: NSObject {
         }
         else {
             guard let decoder = decoder, decoder.isAudioStreamExist, decoder.isEndReached == false else {
+                return true
+            }
+
+            if framebuffer.bufferedAudioDuration >= RDMPEGPlayerMaxAudioBufferSize {
                 return true
             }
 

--- a/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
+++ b/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
@@ -13,7 +13,6 @@ import ReaddleLib
 private let RDMPEGPlayerMinVideoBufferSize: TimeInterval = 0.2
 private let RDMPEGPlayerMaxVideoBufferSize: TimeInterval = 1.0
 private let RDMPEGPlayerMinAudioBufferSize: TimeInterval = 0.2
-private let RDMPEGPlayerMaxAudioBufferSize: TimeInterval = 1.0
 
 private let RDMPEGPlayerInputDecoderKey = "RDMPEGPlayerInputDecoderKey"
 private let RDMPEGPlayerInputNameKey = "RDMPEGPlayerInputNameKey"
@@ -1202,10 +1201,6 @@ public class RDMPEGPlayer: NSObject {
                     return true
                 }
 
-                if framebuffer.bufferedAudioDuration >= RDMPEGPlayerMaxAudioBufferSize {
-                    return true
-                }
-
                 if framebuffer.bufferedAudioDuration > RDMPEGPlayerMinAudioBufferSize {
                     return true
                 }
@@ -1221,10 +1216,6 @@ public class RDMPEGPlayer: NSObject {
                     return true
                 }
 
-                if framebuffer.bufferedAudioDuration >= RDMPEGPlayerMaxAudioBufferSize {
-                    return true
-                }
-
                 if framebuffer.bufferedAudioDuration > RDMPEGPlayerMinAudioBufferSize {
                     return true
                 }
@@ -1237,10 +1228,6 @@ public class RDMPEGPlayer: NSObject {
         }
         else {
             guard let decoder = decoder, decoder.isAudioStreamExist, decoder.isEndReached == false else {
-                return true
-            }
-
-            if framebuffer.bufferedAudioDuration >= RDMPEGPlayerMaxAudioBufferSize {
                 return true
             }
 

--- a/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
+++ b/RDMPEG/RDMPEGPlayer/RDMPEGPlayer.swift
@@ -829,7 +829,9 @@ public class RDMPEGPlayer: NSObject {
             }
         }
 
-        framebuffer.atomicSubtitleFramesAccess {
+        framebuffer.atomicSubtitleFramesAccess { [weak self] in
+            guard let self = self else { return }
+            
             while let nextSubtitleFrame = self.framebuffer.nextSubtitleFrame {
                 let nextSubtitleStartTime = nextSubtitleFrame.position
                 let nextSubtitleEndTime = nextSubtitleStartTime + nextSubtitleFrame.duration
@@ -872,15 +874,10 @@ public class RDMPEGPlayer: NSObject {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func audioCallbackFillData(_ outData: UnsafeMutablePointer<Float>, numFrames: UInt32, numChannels: UInt32) {
-        autoreleasepool { [weak self] in
-            guard let self = self else {
-                memset(outData, 0, Int(numFrames) * Int(numChannels) * MemoryLayout<Float>.size)
-                return
-            }
-            
+        autoreleasepool {
             var outData = outData
 
-            if videoStreamExist && correctionInfo == nil {
+            if self.videoStreamExist && self.correctionInfo == nil {
 #if RD_DEBUG_MPEG_PLAYER
                 L4Logger.logger(forName: "rd.mediaplayer.RDMPEGPlayer").debug("Silence audio while correcting video")
 #endif
@@ -901,7 +898,9 @@ public class RDMPEGPlayer: NSObject {
                     let loggingScope = L4Logger.logger(forName: "rd.mediaplayer.RDMPEGPlayer").loggingScope()
 #endif
 
-                    self.framebuffer.atomicAudioFramesAccess {
+                    framebuffer.atomicAudioFramesAccess { [weak self] in
+                        guard let self = self else { return }
+                        
                         if let nextFrame = self.framebuffer.nextAudioFrame {
                             let delta = self.correctionInfo?.correctionInterval(
                                 withCurrentTime: nextFrame.position
@@ -960,16 +959,16 @@ public class RDMPEGPlayer: NSObject {
                                 playbackStartTime: self.currentInternalTime
                             )
 
-                            DispatchQueue.main.async {
-                                self.setBufferingStateIfNeededAndNotify(false)
+                            DispatchQueue.main.async { [weak self] in
+                                self?.setBufferingStateIfNeededAndNotify(false)
                             }
                         }
                     }
                     else if self.videoStreamExist == false {
                         self.correctionInfo = nil
 
-                        DispatchQueue.main.async {
-                            self.setBufferingStateIfNeededAndNotify(true)
+                        DispatchQueue.main.async { [weak self] in
+                            self?.setBufferingStateIfNeededAndNotify(true)
                         }
                     }
                 }


### PR DESCRIPTION
__Ticket link__

[DOC-14148](https://readdle-j.atlassian.net/browse/DOC-14148)

__PR description__

- I was unable to reproduce the crash, but it seems that the audio player crashes due to overflowing the audio buffer.

__PR submission checklist__

- [x] PR name contains Jira ticket number
- [x] PR have correct target branch
- [x] .s7substat has correct subrepos revisions
- [x] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [ ] Unit tests to cover the critical parts of the code are written
- [ ] Relevant documentation updated / added if needed
- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed


[DOC-14148]: https://readdle-j.atlassian.net/browse/DOC-14148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ